### PR TITLE
Update mlua + rlua, add wrapper for `mlua::Lua::create_proxy`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,5 +18,5 @@
         "tempfile",
         "userdata"
     ],
-    "rust-analyzer.cargo.features": ["mlua","mlua_vendored","mlua_lua54"]
+    "rust-analyzer.cargo.features": ["rlua","rlua_builtin-lua54"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,5 +18,5 @@
         "tempfile",
         "userdata"
     ],
-    "rust-analyzer.cargo.features": ["rlua","rlua_builtin-lua54"]
+    "rust-analyzer.cargo.features": ["mlua","mlua_vendored","mlua_lua54"]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,9 +376,9 @@ dependencies = [
 
 [[package]]
 name = "luajit-src"
-version = "210.3.4+resty073ac54"
+version = "210.4.0+resty124ff8d"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "640b09e99575a442b4da0ef406a78188a1a4313bb9ead7b5b20ec12cc480130f"
+checksum = "f76fb2e2c0c7192e18719d321c9a148f7625c4dcbe3df5f4c19e685e4c286f6c"
 dependencies = [
  "cc",
 ]
@@ -406,9 +406,9 @@ dependencies = [
 
 [[package]]
 name = "mlua"
-version = "0.7.4"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29e2194305aa8301d5da9c1c98640047f4219f6b95c190f6860338ab9872b686"
+checksum = "a82d0b12c7c8d3bdda5933d2aa322c76e4833d822796495f299990ca652bd1bf"
 dependencies = [
  "bstr",
  "cc",
@@ -428,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "mlua_derive"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1713774a29db53a48932596dc943439dd54eb56a9efaace716719cc10fa82d5b"
+checksum = "b9214e60d3cf1643013b107330fcd374ccec1e4ba1eef76e7e5da5e8202e71c0"
 dependencies = [
  "itertools",
  "once_cell",
@@ -618,9 +618,9 @@ dependencies = [
 
 [[package]]
 name = "rlua"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "627ae78424400009e889c43b0c188d0b7af3fe7301b68c03d9cfacb29115408a"
+checksum = "7a8b33d82d6653c447e40067dcf3c970b76e6ebf13807f6acee934f06cc2e35e"
 dependencies = [
  "bitflags",
  "bstr",
@@ -633,9 +633,9 @@ dependencies = [
 
 [[package]]
 name = "rlua-lua51-sys"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e4450088331349b550548841eea3d2d4e3c5956821b405d7240e46296a3ce1"
+checksum = "8ceabd4139b78293f30219c6a5583da4bd339e0742b5eaa82c9ecd744d9e7b90"
 dependencies = [
  "cc",
  "libc",
@@ -644,9 +644,9 @@ dependencies = [
 
 [[package]]
 name = "rlua-lua53-sys"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf3bb08bb9f395283c244bef1dd56b9d7091d5450afebfc1f95b965ba147833"
+checksum = "7a5895b7a0be569b48f7e186d3b5b4438abda7fcd7374d49235d75827281d3cb"
 dependencies = [
  "cc",
  "libc",
@@ -655,9 +655,9 @@ dependencies = [
 
 [[package]]
 name = "rlua-lua54-sys"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4e1fdfc6a5f7acfa1b1fe26c5076b54f5ebd6818b5982460c39844c8b859370"
+checksum = "9ca23c19a6782d115dce7e11be719b4dbea833acd0d0599e963abf4f31ad9137"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,8 +49,8 @@ rlua_system-lua54 = ["rlua/system-lua54"]
 [dependencies]
 bstr = {version = "0.2", default_features = false, features = ["std"]}
 itertools = "0.10.3"
-mlua = {version = "0.7.4", optional = true, default_features = false}
-rlua = {version = "0.19.1", optional = true, default_features = false}
+mlua = {version = "0.8.1", optional = true, default_features = false}
+rlua = {version = "0.19.2", optional = true, default_features = false}
 serde = {version = "1.0.136", features = ["derive"]}
 tealr_derive = {version = "0.8.0", optional = true, path = "./tealr_derive"}
 
@@ -178,6 +178,11 @@ required-features = ["mlua"]
 [[example]]
 name = "mlua_manual_documentation"
 path = "examples/mlua/manual_documentation.rs"
+required-features = ["mlua"]
+
+[[example]]
+name = "mlua_userdata_proxy"
+path = "examples/mlua/userdata_proxy.rs"
 required-features = ["mlua"]
 
 [package.metadata.docs.rs]

--- a/examples/mlua/userdata_proxy.rs
+++ b/examples/mlua/userdata_proxy.rs
@@ -45,6 +45,8 @@ impl tealr::mlu::ExportInstances for Export {
         instance_collector: &mut T,
     ) -> mlua::Result<()> {
         instance_collector.document_instance("Documentation for the exposed static proxy");
+
+        // note that the proxy type is NOT `Example` but a special mlua type, which is represented differnetly in .d.tl as well
         instance_collector.add_instance("Example".into(), UserDataProxy::<Example>::new)
     }
 }

--- a/examples/mlua/userdata_proxy.rs
+++ b/examples/mlua/userdata_proxy.rs
@@ -7,7 +7,6 @@ use tealr::{
 };
 //this example shows how to expose a `proxy` type to enable calling static global functions from anywhere.
 
-
 //First, create the struct you want to export to lua.
 //instead of both deriving UserData and TypeName you can also
 //derive TealDerive, which does both. However you will still need to import
@@ -39,7 +38,6 @@ impl tealr::mlu::ExportInstances for Export {
         instance_collector.add_instance("Example".into(), |c| UserDataProxy::<Example>::new(c))
     }
 }
-
 
 fn main() -> Result<()> {
     //lets first generate the definition file

--- a/examples/mlua/userdata_proxy.rs
+++ b/examples/mlua/userdata_proxy.rs
@@ -61,6 +61,7 @@ fn main() -> Result<()> {
 
     //how you pass this type to lua hasn't changed:
     let lua = Lua::new();
+    tealr::mlu::set_global_env::<Export>(&lua).unwrap();
     let globals = lua.globals();
     globals.set("test", Example {})?;
     let code = "
@@ -68,6 +69,7 @@ print(test:example_method(1))
 print(test:example_method_mut(2,\"test\"))
 print(test.example_function({}))
 print(test.example_function_mut(true))
+print(Example.example_function({}))
     ";
     lua.load(code).set_name("test?")?.eval()?;
     Ok(())

--- a/examples/mlua/userdata_proxy.rs
+++ b/examples/mlua/userdata_proxy.rs
@@ -35,7 +35,7 @@ impl tealr::mlu::ExportInstances for Export {
         instance_collector: &mut T,
     ) -> mlua::Result<()> {
         instance_collector.document_instance("Documentation for the exposed static proxy");
-        instance_collector.add_instance("Example".into(), |c| UserDataProxy::<Example>::new(c))
+        instance_collector.add_instance("Example".into(), UserDataProxy::<Example>::new)
     }
 }
 

--- a/examples/mlua/userdata_proxy.rs
+++ b/examples/mlua/userdata_proxy.rs
@@ -14,7 +14,7 @@ use tealr::{
 //The clone is only needed because one of the example functions has it as a parameter
 #[derive(Clone, UserData, TypeName)]
 struct Example {
-    float : f32,
+    float: f32,
 }
 
 //now, implement TealData. This tells rlua what methods are available and tealr what the types are
@@ -30,12 +30,13 @@ impl TealData for Example {
     }
 
     fn add_fields<'lua, F: tealr::mlu::TealDataFields<'lua, Self>>(fields: &mut F) {
-        fields.add_field_method_get("example_field", |_,s : &Example| Ok(s.float));
-        fields.add_field_method_set("example_field_set", |_,s : &mut Example,v : f32| Ok(s.float = v));
-        fields.add_field_function_get("example_static_field", |_,_| Ok("my_field"));
-        fields.add_field_function_get("example_static_field_mut", |_,_| Ok("my_mut_field"));
+        fields.add_field_method_get("example_field", |_, s: &Example| Ok(s.float));
+        fields.add_field_method_set("example_field_set", |_, s: &mut Example, v: f32| {
+            Ok(s.float = v)
+        });
+        fields.add_field_function_get("example_static_field", |_, _| Ok("my_field"));
+        fields.add_field_function_get("example_static_field_mut", |_, _| Ok("my_mut_field"));
     }
-    
 }
 
 // document and expose the global proxy
@@ -76,7 +77,7 @@ fn main() -> Result<()> {
     let lua = Lua::new();
     tealr::mlu::set_global_env::<Export>(&lua).unwrap();
     let globals = lua.globals();
-    globals.set("test", Example {float: 42.0})?;
+    globals.set("test", Example { float: 42.0 })?;
     let code = "
 print(\" Calling from `test` :\")
 print(test:example_method(1))

--- a/examples/mlua/userdata_proxy.rs
+++ b/examples/mlua/userdata_proxy.rs
@@ -1,0 +1,76 @@
+use tealr::{
+    mlu::{
+        mlua::{Lua, Result},
+        TealData, TealDataMethods, UserData, UserDataProxy,
+    },
+    TypeName, TypeWalker,
+};
+//this example shows how to expose a `proxy` type to enable calling static global functions from anywhere.
+
+
+//First, create the struct you want to export to lua.
+//instead of both deriving UserData and TypeName you can also
+//derive TealDerive, which does both. However you will still need to import
+//UserData and TypeName
+//The clone is only needed because one of the example functions has it as a parameter
+#[derive(Clone, UserData, TypeName)]
+struct Example {}
+
+//now, implement TealData. This tells rlua what methods are available and tealr what the types are
+impl TealData for Example {
+    //implement your methods/functions
+    fn add_methods<'lua, T: TealDataMethods<'lua, Self>>(methods: &mut T) {
+        methods.add_method("example_method", |_, _, x: i8| Ok(x));
+        methods.add_method_mut("example_method_mut", |_, _, x: (i8, String)| Ok(x.1));
+        methods.add_function("example_function", |_, x: Vec<String>| Ok((x, 8)));
+        methods.add_function_mut("example_function_mut", |_, x: (bool, Option<Example>)| {
+            Ok(x)
+        })
+    }
+}
+
+// document and expose the global proxy
+struct Export;
+impl tealr::mlu::ExportInstances for Export {
+    fn add_instances<'lua, T: tealr::mlu::InstanceCollector<'lua>>(
+        instance_collector: &mut T,
+    ) -> mlua::Result<()> {
+        instance_collector.document_instance("Documentation for the exposed static proxy");
+        instance_collector.add_instance("Example".into(), |c| UserDataProxy::<Example>::new(c))
+    }
+}
+
+
+fn main() -> Result<()> {
+    //lets first generate the definition file
+    let file_contents = TypeWalker::new() //creates the generator
+        //tells it that we want to generate Example
+        //add more calls to process_type to generate more types in the same file
+        .process_type::<Example>()
+        // enable documenting the global
+        .document_global_instance::<Export>()?
+        //generate the file
+        .generate_global("test")
+        //the name parameter for TealDataMethods::{add_method,add_method_mut,add_function,add_function_mut}
+        //takes anything that can be used as a &[u8]
+        //this is to match the types from UserDataMethods
+        //however, as we turn it back into a string it is technically possible to get an error
+        //in this case, as &str's where used it can't happen though, so the .expect is fine
+        .expect("oh no :(");
+
+    //normally you would now save the file somewhere.
+    println!("{}\n ", file_contents);
+
+    //how you pass this type to lua hasn't changed:
+    let lua = Lua::new();
+    let globals = lua.globals();
+    globals.set("test", Example {})?;
+    let code = "
+print(test:example_method(1))
+print(test:example_method_mut(2,\"test\"))
+print(test.example_function({}))
+print(test.example_function_mut(true))
+    ";
+    lua.load(code).set_name("test?")?.eval()?;
+    Ok(())
+}

--- a/src/exported_function.rs
+++ b/src/exported_function.rs
@@ -21,7 +21,7 @@ fn add_generics(v: &[crate::TealType], generics: &mut std::collections::HashSet<
 }
 
 ///Contains the data needed to write down the type of a function
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct ExportedFunction {
     ///Name of the function
     pub name: NameContainer,

--- a/src/mlu.rs
+++ b/src/mlu.rs
@@ -5,6 +5,7 @@ pub(crate) mod teal_data;
 mod teal_data_fields;
 pub(crate) mod teal_data_methods;
 mod typed_function;
+/// Module containing functionality to do with user data proxies
 pub mod user_data_proxy;
 pub(crate) mod user_data_wrapper;
 use std::borrow::Cow;

--- a/src/mlu.rs
+++ b/src/mlu.rs
@@ -5,16 +5,16 @@ pub(crate) mod teal_data;
 mod teal_data_fields;
 pub(crate) mod teal_data_methods;
 mod typed_function;
-pub(crate) mod user_data_wrapper;
 pub mod user_data_proxy;
+pub(crate) mod user_data_wrapper;
 use std::borrow::Cow;
 
 pub use self::{
     teal_data::TealData,
     teal_data_methods::{set_global_env, ExportInstances, InstanceCollector, TealDataMethods},
     typed_function::TypedFunction,
-    user_data_wrapper::UserDataWrapper,
     user_data_proxy::UserDataProxy,
+    user_data_wrapper::UserDataWrapper,
 };
 pub use mlua;
 pub use teal_data_fields::TealDataFields;

--- a/src/mlu.rs
+++ b/src/mlu.rs
@@ -6,6 +6,7 @@ mod teal_data_fields;
 pub(crate) mod teal_data_methods;
 mod typed_function;
 pub(crate) mod user_data_wrapper;
+pub mod user_data_proxy;
 use std::borrow::Cow;
 
 pub use self::{
@@ -13,6 +14,7 @@ pub use self::{
     teal_data_methods::{set_global_env, ExportInstances, InstanceCollector, TealDataMethods},
     typed_function::TypedFunction,
     user_data_wrapper::UserDataWrapper,
+    user_data_proxy::UserDataProxy,
 };
 pub use mlua;
 pub use teal_data_fields::TealDataFields;

--- a/src/mlu/typed_function.rs
+++ b/src/mlu/typed_function.rs
@@ -104,15 +104,14 @@ where
         fun.inner_function
     }
 }
-impl<'lua, 'callback, Params, Response> TypedFunction<'lua, Params, Response>
+impl<'lua, Params, Response> TypedFunction<'lua, Params, Response>
 where
-    'lua: 'callback,
-    Params: FromLuaMulti<'callback> + TealMultiValue,
-    Response: ToLuaMulti<'callback> + TealMultiValue,
+    Params: FromLuaMulti<'lua> + TealMultiValue,
+    Response: ToLuaMulti<'lua> + TealMultiValue,
 {
     ///make a typed function directly from a Rust one.
     pub fn from_rust<
-        Func: 'static + crate::mlu::MaybeSend + Fn(&'callback Lua, Params) -> mlua::Result<Response>,
+        Func: 'static + crate::mlu::MaybeSend + Fn(&'lua Lua, Params) -> mlua::Result<Response>,
     >(
         func: Func,
         lua: &'lua Lua,
@@ -125,7 +124,7 @@ where
     }
     ///make a typed function directly from a Rust one.
     pub fn from_rust_mut<
-        Func: 'static + crate::mlu::MaybeSend + FnMut(&'callback Lua, Params) -> mlua::Result<Response>,
+        Func: 'static + crate::mlu::MaybeSend + FnMut(&'lua Lua, Params) -> mlua::Result<Response>,
     >(
         func: Func,
         lua: &'lua Lua,

--- a/src/mlu/user_data_proxy.rs
+++ b/src/mlu/user_data_proxy.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use mlua::{AnyUserData, Error, Lua, ToLua, UserData};
 
-use crate::{TypeBody, TypeName, RecordGenerator, EnumGenerator};
+use crate::{EnumGenerator, RecordGenerator, TypeBody, TypeName};
 
 /// A userdata which can be used as a static proxy
 pub trait StaticUserdata: UserData + 'static {}
@@ -12,7 +12,7 @@ impl<T: UserData + 'static> StaticUserdata for T {}
 ///
 /// the `TypeName` for this struct is implemented as the `TypeName` for `T` concatenated with "Class".
 /// For example, if your type is called "MyType", the proxy would have "MyTypeClass" for a `TypeName`.
-/// 
+///
 /// the documentation for this proxy receives only `static` methods, i.e. those created via:
 /// - `TealDataMethods::add_function`
 /// - `TealDataMethods::add_meta_function`
@@ -22,7 +22,7 @@ impl<T: UserData + 'static> StaticUserdata for T {}
 /// - `TealDataFields::add_field_function_get`
 /// - `TealDataFields::add_field_function_set`
 /// - `TealDataFields::add_meta_field_with`
-/// 
+///
 /// The type documentation is overriden as well.
 pub struct UserDataProxy<'lua, T: StaticUserdata> {
     user_data: AnyUserData<'lua>,
@@ -53,33 +53,31 @@ impl<T: StaticUserdata + TypeBody + TypeName> TypeBody for UserDataProxy<'_, T> 
         let generator = T::get_type_body();
         // extract only "functions"
         let type_name = Self::get_type_parts();
-        let type_name_string = type_name[..type_name.len()-1].iter().map(|v| v.to_string()).collect::<Vec<_>>().join("");
+        let type_name_string = type_name[..type_name.len() - 1]
+            .iter()
+            .map(|v| v.to_string())
+            .collect::<Vec<_>>()
+            .join("");
         match generator {
             crate::TypeGenerator::Record(record_generator) => {
-                crate::TypeGenerator::Record(
-                    Box::new(
-                        RecordGenerator{
-                            // we overwrite anything which is not static
-                            type_name,
-                            type_doc: format!("Collection of static methods for [`{}`].", type_name_string),
-                            fields: Default::default(),
-                            methods: Default::default(),
-                            mut_methods: Default::default(),
-                            meta_method: Default::default(),
-                            meta_method_mut: Default::default(),
-                            ..record_generator.as_ref().clone()
-                        }
-                    )
-                )
-            },
+                crate::TypeGenerator::Record(Box::new(RecordGenerator {
+                    // we overwrite anything which is not static
+                    type_name,
+                    type_doc: format!("Collection of static methods for [`{}`].", type_name_string),
+                    fields: Default::default(),
+                    methods: Default::default(),
+                    mut_methods: Default::default(),
+                    meta_method: Default::default(),
+                    meta_method_mut: Default::default(),
+                    ..record_generator.as_ref().clone()
+                }))
+            }
             crate::TypeGenerator::Enum(enum_generator) => {
-                crate::TypeGenerator::Enum(
-                    EnumGenerator{
-                        name: Self::get_type_parts(),
-                        ..enum_generator
-                    }
-                )
-            },
+                crate::TypeGenerator::Enum(EnumGenerator {
+                    name: Self::get_type_parts(),
+                    ..enum_generator
+                })
+            }
         }
     }
 }

--- a/src/mlu/user_data_proxy.rs
+++ b/src/mlu/user_data_proxy.rs
@@ -1,46 +1,45 @@
 use std::marker::PhantomData;
 
-use mlua::{UserData, AnyUserData, Lua, Error, ToLua};
+use mlua::{AnyUserData, Error, Lua, ToLua, UserData};
 
-use crate::{TypeName, TypeBody};
+use crate::{TypeBody, TypeName};
 
 /// A userdata which can be used as a static proxy
 pub trait StaticUserdata: UserData + 'static {}
-impl <T : UserData + 'static>StaticUserdata for T {}
+impl<T: UserData + 'static> StaticUserdata for T {}
 
 /// A newtype storing userdata created via [`mlua::Lua::create_proxy`].
-/// 
-/// if `T` implements TypeName or TypeBody the implementations are forwarded to this type. 
-pub struct UserDataProxy<'lua,T : StaticUserdata>{
+///
+/// if `T` implements TypeName or TypeBody the implementations are forwarded to this type.
+pub struct UserDataProxy<'lua, T: StaticUserdata> {
     user_data: AnyUserData<'lua>,
-    ph_: PhantomData<T>
+    ph_: PhantomData<T>,
 }
 
-impl <'lua, T : StaticUserdata> UserDataProxy<'lua, T> {
+impl<'lua, T: StaticUserdata> UserDataProxy<'lua, T> {
     /// Creates a new UserDataProxy
-    pub fn new(lua: &'lua Lua) -> Result<Self,Error>{
-        Ok(Self{
+    pub fn new(lua: &'lua Lua) -> Result<Self, Error> {
+        Ok(Self {
             user_data: lua.create_proxy::<T>()?,
             ph_: Default::default(),
         })
     }
 }
 
-impl <T : StaticUserdata + TypeName>TypeName for UserDataProxy<'_, T> {
+impl<T: StaticUserdata + TypeName> TypeName for UserDataProxy<'_, T> {
     fn get_type_parts() -> std::borrow::Cow<'static, [crate::NamePart]> {
         T::get_type_parts()
     }
 }
 
-impl <T : StaticUserdata + TypeBody>TypeBody for UserDataProxy<'_, T> {
+impl<T: StaticUserdata + TypeBody> TypeBody for UserDataProxy<'_, T> {
     fn get_type_body() -> crate::TypeGenerator {
         T::get_type_body()
     }
 }
 
-impl <'lua,T : StaticUserdata> ToLua<'lua> for UserDataProxy<'lua, T> {
+impl<'lua, T: StaticUserdata> ToLua<'lua> for UserDataProxy<'lua, T> {
     fn to_lua(self, lua: &'lua Lua) -> mlua::Result<mlua::Value<'lua>> {
         self.user_data.to_lua(lua)
     }
 }
-

--- a/src/mlu/user_data_proxy.rs
+++ b/src/mlu/user_data_proxy.rs
@@ -8,9 +8,22 @@ use crate::{TypeBody, TypeName, RecordGenerator, EnumGenerator};
 pub trait StaticUserdata: UserData + 'static {}
 impl<T: UserData + 'static> StaticUserdata for T {}
 
-/// A newtype storing userdata created via [`mlua::Lua::create_proxy`].
+/// A newtype storing proxy userdata created via [`mlua::Lua::create_proxy`].
 ///
-/// if `T` implements TypeName or TypeBody the implementations are forwarded to this type.
+/// the `TypeName` for this struct is implemented as the `TypeName` for `T` concatenated with "Class".
+/// For example, if your type is called "MyType", the proxy would have "MyTypeClass" for a `TypeName`.
+/// 
+/// the documentation for this proxy receives only `static` methods, i.e. those created via:
+/// - `TealDataMethods::add_function`
+/// - `TealDataMethods::add_meta_function`
+/// - `TealDataMethods::add_meta_function_mut`
+/// - `TealDataMethods::add_function_mut`
+/// - `TealDataMethods::add_async_function`
+/// - `TealDataFields::add_field_function_get`
+/// - `TealDataFields::add_field_function_set`
+/// - `TealDataFields::add_meta_field_with`
+/// 
+/// The type documentation is overriden as well.
 pub struct UserDataProxy<'lua, T: StaticUserdata> {
     user_data: AnyUserData<'lua>,
     ph_: PhantomData<T>,
@@ -39,17 +52,16 @@ impl<T: StaticUserdata + TypeBody + TypeName> TypeBody for UserDataProxy<'_, T> 
     fn get_type_body() -> crate::TypeGenerator {
         let generator = T::get_type_body();
         // extract only "functions"
+        let type_name = Self::get_type_parts();
+        let type_name_string = type_name[..type_name.len()-1].iter().map(|v| v.to_string()).collect::<Vec<_>>().join("");
         match generator {
             crate::TypeGenerator::Record(record_generator) => {
                 crate::TypeGenerator::Record(
                     Box::new(
                         RecordGenerator{
-                            // TODO: deal with this to reflect this is the "Class" version 
-                            type_name: Self::get_type_parts(),
-                            // documentation: todo!(),
-                            // type_doc: todo!(),
-
                             // we overwrite anything which is not static
+                            type_name,
+                            type_doc: format!("Collection of static methods for [`{}`].", type_name_string),
                             fields: Default::default(),
                             methods: Default::default(),
                             mut_methods: Default::default(),
@@ -64,7 +76,7 @@ impl<T: StaticUserdata + TypeBody + TypeName> TypeBody for UserDataProxy<'_, T> 
                 crate::TypeGenerator::Enum(
                     EnumGenerator{
                         name: Self::get_type_parts(),
-                        ..enum_generator.clone()
+                        ..enum_generator
                     }
                 )
             },

--- a/src/mlu/user_data_proxy.rs
+++ b/src/mlu/user_data_proxy.rs
@@ -1,0 +1,46 @@
+use std::marker::PhantomData;
+
+use mlua::{UserData, AnyUserData, Lua, Error, ToLua};
+
+use crate::{TypeName, TypeBody};
+
+/// A userdata which can be used as a static proxy
+pub trait StaticUserdata: UserData + 'static {}
+impl <T : UserData + 'static>StaticUserdata for T {}
+
+/// A newtype storing userdata created via [`mlua::Lua::create_proxy`].
+/// 
+/// if `T` implements TypeName or TypeBody the implementations are forwarded to this type. 
+pub struct UserDataProxy<'lua,T : StaticUserdata>{
+    user_data: AnyUserData<'lua>,
+    ph_: PhantomData<T>
+}
+
+impl <'lua, T : StaticUserdata> UserDataProxy<'lua, T> {
+    /// Creates a new UserDataProxy
+    pub fn new(lua: &'lua Lua) -> Result<Self,Error>{
+        Ok(Self{
+            user_data: lua.create_proxy::<T>()?,
+            ph_: Default::default(),
+        })
+    }
+}
+
+impl <T : StaticUserdata + TypeName>TypeName for UserDataProxy<'_, T> {
+    fn get_type_parts() -> std::borrow::Cow<'static, [crate::NamePart]> {
+        T::get_type_parts()
+    }
+}
+
+impl <T : StaticUserdata + TypeBody>TypeBody for UserDataProxy<'_, T> {
+    fn get_type_body() -> crate::TypeGenerator {
+        T::get_type_body()
+    }
+}
+
+impl <'lua,T : StaticUserdata> ToLua<'lua> for UserDataProxy<'lua, T> {
+    fn to_lua(self, lua: &'lua Lua) -> mlua::Result<mlua::Value<'lua>> {
+        self.user_data.to_lua(lua)
+    }
+}
+

--- a/src/type_representation.rs
+++ b/src/type_representation.rs
@@ -1,3 +1,5 @@
+use itertools::Itertools;
+
 use crate::teal_multivalue::TealMultiValue;
 
 macro_rules! impl_type_name_life_time {
@@ -134,6 +136,13 @@ pub enum NamePart {
     //Appended(Cow<'static, [NamePart]>),
 }
 
+impl Display for NamePart {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_ref_str());
+        Ok(())
+    }
+}
+
 impl NamePart {
     ///Turn a NamePart into a `Cow<'static, str>`
     pub fn as_ref_str(&self) -> &Cow<'static, str> {
@@ -214,7 +223,7 @@ pub trait TypeName {
 
 use std::{
     borrow::Cow,
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, HashMap}, fmt::Display,
 };
 
 use crate::{TealType, TypeGenerator};

--- a/src/type_representation.rs
+++ b/src/type_representation.rs
@@ -1,4 +1,4 @@
-use itertools::Itertools;
+
 
 use crate::teal_multivalue::TealMultiValue;
 
@@ -138,8 +138,7 @@ pub enum NamePart {
 
 impl Display for NamePart {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_ref_str());
-        Ok(())
+        f.write_str(self.as_ref_str())
     }
 }
 

--- a/src/type_representation.rs
+++ b/src/type_representation.rs
@@ -1,5 +1,3 @@
-
-
 use crate::teal_multivalue::TealMultiValue;
 
 macro_rules! impl_type_name_life_time {
@@ -222,7 +220,8 @@ pub trait TypeName {
 
 use std::{
     borrow::Cow,
-    collections::{BTreeMap, HashMap}, fmt::Display,
+    collections::{BTreeMap, HashMap},
+    fmt::Display,
 };
 
 use crate::{TealType, TypeGenerator};


### PR DESCRIPTION
- Bumps versions
- Adds new example for userdata proxies and globals
- closes #59 and #46 