### PR TITLE
Fix building on 32bit systems

### DIFF
--- a/src/mlu/picker_macro.rs
+++ b/src/mlu/picker_macro.rs
@@ -287,6 +287,9 @@ impl_from_exact!(i8, mlua::Value::Integer(x), x, TryFromIntError);
 impl_from_exact!(u8, mlua::Value::Integer(x), x, TryFromIntError);
 impl_from_exact!(i16, mlua::Value::Integer(x), x, TryFromIntError);
 impl_from_exact!(u16, mlua::Value::Integer(x), x, TryFromIntError);
+#[cfg(target_pointer_width = "32")]
+impl_from_exact_non_failing!(i32, mlua::Value::Integer(x), x);
+#[cfg(target_pointer_width = "64")]
 impl_from_exact!(i32, mlua::Value::Integer(x), x, TryFromIntError);
 impl_from_exact!(u32, mlua::Value::Integer(x), x, TryFromIntError);
 impl_from_exact_non_failing!(i64, mlua::Value::Integer(x), x);

--- a/src/rlu/picker_macro.rs
+++ b/src/rlu/picker_macro.rs
@@ -297,6 +297,9 @@ impl_from_exact!(i8, rlua::Value::Integer(x), x, TryFromIntError);
 impl_from_exact!(u8, rlua::Value::Integer(x), x, TryFromIntError);
 impl_from_exact!(i16, rlua::Value::Integer(x), x, TryFromIntError);
 impl_from_exact!(u16, rlua::Value::Integer(x), x, TryFromIntError);
+#[cfg(target_pointer_width = "32")]
+impl_from_exact_non_failing!(i32, rlua::Value::Integer(x), x);
+#[cfg(target_pointer_width = "64")]
 impl_from_exact!(i32, rlua::Value::Integer(x), x, TryFromIntError);
 impl_from_exact!(u32, rlua::Value::Integer(x), x, TryFromIntError);
 impl_from_exact_non_failing!(i64, rlua::Value::Integer(x), x);


### PR DESCRIPTION
I was cross-compiling my project from 64bit Linux to 32bit Windows, and one of the impl macros were failing. Turns out, Lua's internal `Integer` type is different for 32bit and 64bit systems, and `try_into` depends on that. 

Original error:
```
error[E0271]: type mismatch resolving `<i32 as TryFrom<i32>>::Error == TryFromIntError`
   --> /path/to/code/tealr-0.9.0-alpha4/src/mlu/picker_macro.rs:150:40
    |
150 |                     $conv => $bound_on.try_into().map_err(|x: $error| {
    |                                        ^^^^^^^^ expected enum `Infallible`, found struct `TryFromIntError`
...
290 | impl_from_exact!(i32, mlua::Value::Integer(x), x, TryFromIntError);
    | ------------------------------------------------------------------ in this macro invocation
    |
    = note: this error originates in the macro `impl_from_exact` (in Nightly builds, run with -Z macro-backtrace for more info)
```