### PR TITLE
Fix rlua - lua51 not building

### DIFF
--- a/src/rlu.rs
+++ b/src/rlu.rs
@@ -66,6 +66,10 @@ pub fn get_type_name(value: &rlua::Value) -> &'static str {
         rlua::Value::Nil => return "Nil",
         rlua::Value::Boolean(_) => bool::to_old_type_parts(),
         rlua::Value::LightUserData(_) => return "LightUserData",
+        #[cfg(all(
+            not(feature = "rlua_builtin-lua51"),
+            not(feature = "rlua_system-lua51")
+        ))]
         rlua::Value::Integer(_) => rlua::Integer::to_old_type_parts(),
         rlua::Value::Number(_) => rlua::Number::to_old_type_parts(),
         rlua::Value::String(_) => String::to_old_type_parts(),

--- a/src/rlu/generics.rs
+++ b/src/rlu/generics.rs
@@ -16,6 +16,10 @@ macro_rules! create_generic_rlua {
             Nil,
             Boolean(bool),
             LightUserData($crate::rlu::rlua::LightUserData),
+            #[cfg(all(
+                not(feature = "rlua_builtin-lua51"),
+                not(feature = "rlua_system-lua51")
+            ))]
             Integer($crate::rlu::rlua::Integer),
             Number($crate::rlu::rlua::Number),
             String($crate::rlu::rlua::String<'lua>),
@@ -42,6 +46,10 @@ macro_rules! create_generic_rlua {
                     Nil => $type_name::Nil,
                     Boolean(x) => $type_name::Boolean(x),
                     LightUserData(x) => $type_name::LightUserData(x),
+                    #[cfg(all(
+                        not(feature = "rlua_builtin-lua51"),
+                        not(feature = "rlua_system-lua51")
+                    ))]
                     Integer(x) => $type_name::Integer(x),
                     Number(x) => $type_name::Number(x),
                     String(x) => $type_name::String(x),
@@ -60,6 +68,10 @@ macro_rules! create_generic_rlua {
                     Nil => $crate::rlu::rlua::Value::Nil,
                     Boolean(x) => $crate::rlu::rlua::Value::Boolean(x),
                     LightUserData(x) => $crate::rlu::rlua::Value::LightUserData(x),
+                    #[cfg(all(
+                        not(feature = "rlua_builtin-lua51"),
+                        not(feature = "rlua_system-lua51")
+                    ))]
                     Integer(x) => $crate::rlu::rlua::Value::Integer(x),
                     Number(x) => $crate::rlu::rlua::Value::Number(x),
                     String(x) => $crate::rlu::rlua::Value::String(x),

--- a/src/rlu/picker_macro.rs
+++ b/src/rlu/picker_macro.rs
@@ -276,20 +276,72 @@ impl_from_exact_non_failing!(Table<'lua>, rlua::Value::Table(x), x);
 
 impl_from_exact_non_failing!(rlua::String<'lua>, rlua::Value::String(x), x);
 
+#[cfg(all(
+    not(feature = "rlua_builtin-lua51"),
+    not(feature = "rlua_system-lua51")
+))]
 impl_from_exact!(i8, rlua::Value::Integer(x), x, TryFromIntError);
+#[cfg(all(
+    not(feature = "rlua_builtin-lua51"),
+    not(feature = "rlua_system-lua51")
+))]
 impl_from_exact!(u8, rlua::Value::Integer(x), x, TryFromIntError);
+#[cfg(all(
+    not(feature = "rlua_builtin-lua51"),
+    not(feature = "rlua_system-lua51")
+))]
 impl_from_exact!(i16, rlua::Value::Integer(x), x, TryFromIntError);
+#[cfg(all(
+    not(feature = "rlua_builtin-lua51"),
+    not(feature = "rlua_system-lua51")
+))]
 impl_from_exact!(u16, rlua::Value::Integer(x), x, TryFromIntError);
-#[cfg(target_pointer_width = "32")]
+#[cfg(all(
+    target_pointer_width = "32",
+    not(feature = "rlua_builtin-lua51"),
+    not(feature = "rlua_system-lua51")
+))]
 impl_from_exact_non_failing!(i32, rlua::Value::Integer(x), x);
-#[cfg(target_pointer_width = "64")]
+#[cfg(all(
+    target_pointer_width = "64",
+    not(feature = "rlua_builtin-lua51"),
+    not(feature = "rlua_system-lua51")
+))]
 impl_from_exact!(i32, rlua::Value::Integer(x), x, TryFromIntError);
+#[cfg(all(
+    not(feature = "rlua_builtin-lua51"),
+    not(feature = "rlua_system-lua51")
+))]
 impl_from_exact!(u32, rlua::Value::Integer(x), x, TryFromIntError);
+#[cfg(all(
+    not(feature = "rlua_builtin-lua51"),
+    not(feature = "rlua_system-lua51")
+))]
 impl_from_exact_non_failing!(i64, rlua::Value::Integer(x), x);
+#[cfg(all(
+    not(feature = "rlua_builtin-lua51"),
+    not(feature = "rlua_system-lua51")
+))]
 impl_from_exact!(u64, rlua::Value::Integer(x), x, TryFromIntError);
+#[cfg(all(
+    not(feature = "rlua_builtin-lua51"),
+    not(feature = "rlua_system-lua51")
+))]
 impl_from_exact_non_failing!(i128, rlua::Value::Integer(x), x);
+#[cfg(all(
+    not(feature = "rlua_builtin-lua51"),
+    not(feature = "rlua_system-lua51")
+))]
 impl_from_exact!(u128, rlua::Value::Integer(x), x, TryFromIntError);
+#[cfg(all(
+    not(feature = "rlua_builtin-lua51"),
+    not(feature = "rlua_system-lua51")
+))]
 impl_from_exact!(isize, rlua::Value::Integer(x), x, TryFromIntError);
+#[cfg(all(
+    not(feature = "rlua_builtin-lua51"),
+    not(feature = "rlua_system-lua51")
+))]
 impl_from_exact!(usize, rlua::Value::Integer(x), x, TryFromIntError);
 
 impl_from_exact_non_failing!(f64, rlua::Value::Number(x), x);


### PR DESCRIPTION
`rlua::Value::Integer` is only available in lua 5.3+ as mentioned [here](https://github.com/mlua-rs/rlua/blob/6152008989fb43a63c0632dc39dea25f40390ac9/src/value.rs#L31).

This commit fixes tealr not building at all for flags `rlua_builtin-lua51` and `rlua_system-lua51`.

Before this commit:
```sh
$ cargo run --example rlua_manual -F rlua,rlua_system-lua51
<65 errors>
$ cargo run --example rlua_manual -F rlua,rlua_builtin-lua51
<65 errors>
```

After this commit, all of these build successfully:
```sh
cargo run --example rlua_manual -F rlua,rlua_system-lua51
cargo run --example rlua_manual -F rlua,rlua_builtin-lua51

cargo run --example rlua_manual -F rlua,rlua_system-lua53
cargo run --example rlua_manual -F rlua,rlua_builtin-lua53

cargo run --example rlua_manual -F rlua,rlua_system-lua54
cargo run --example rlua_manual -F rlua,rlua_builtin-lua54
```