### PR TITLE
Added the abiltiy to name ExportedFunction parameters

### DIFF
--- a/examples/manual.rs
+++ b/examples/manual.rs
@@ -41,6 +41,7 @@ impl TealData for Example {
             Ok(x)
         })
     }
+
     fn add_fields<F: tealr::mlu::TealDataFields<Self>>(fields: &mut F) {
         fields.add_field_method_get("example_field", |_, this| Ok(this.0));
         fields.add_field_method_set("example_field", |_, this, value| {
@@ -62,6 +63,7 @@ impl UserData for Example {
         let mut wrapper = UserDataWrapper::from_user_data_fields(fields);
         <Self as TealData>::add_fields(&mut wrapper)
     }
+
     fn add_methods<T: UserDataMethods<Self>>(methods: &mut T) {
         let mut wrapper = UserDataWrapper::from_user_data_methods(methods);
         <Self as TealData>::add_methods(&mut wrapper)

--- a/examples/manual_documentation.rs
+++ b/examples/manual_documentation.rs
@@ -51,6 +51,7 @@ impl TealData for Example {
         });
         methods.generate_help();
     }
+
     fn add_fields<F: tealr::mlu::TealDataFields<Self>>(fields: &mut F) {
         fields.document("This is an example field");
         fields.add_field_method_get("example", |_, this| Ok(this.0));
@@ -74,6 +75,7 @@ impl UserData for Example {
         let mut wrapper = UserDataWrapper::from_user_data_fields(fields);
         <Self as TealData>::add_fields(&mut wrapper);
     }
+
     fn add_methods<T: UserDataMethods<Self>>(methods: &mut T) {
         let mut wrapper = UserDataWrapper::from_user_data_methods(methods);
         <Self as TealData>::add_methods(&mut wrapper);

--- a/src/export_instance.rs
+++ b/src/export_instance.rs
@@ -17,6 +17,7 @@ impl crate::mlu::InstanceCollector for InstanceWalker {
         self.add_instance::<T>(global_name.into());
         Ok(self)
     }
+
     fn document_instance(&mut self, doc: &'static str) -> &mut Self {
         self.document_instance(doc);
         self
@@ -30,6 +31,7 @@ impl InstanceWalker {
             instances: Default::default(),
         }
     }
+
     #[allow(dead_code)]
     fn add_instance<T: ToTypename>(&mut self, name: Cow<'static, str>) {
         let teal_type = T::get_type_parts_as_global();
@@ -44,6 +46,7 @@ impl InstanceWalker {
             ty: T::to_typename(),
         });
     }
+
     #[allow(dead_code)]
     fn document_instance(&mut self, doc: &'static str) {
         self.doc.push_str(doc);

--- a/src/exported_function.rs
+++ b/src/exported_function.rs
@@ -74,6 +74,23 @@ impl ExportedFunction {
             returns: R::get_types(),
         }
     }
+
+    /// Give the [`params`] a name in case this is not automatically derived.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if the given argument does not have the same number of fields as [`params`].
+    pub fn name_parameters(
+        &mut self,
+        names: impl ExactSizeIterator<Item = impl Into<Name>>,
+    ) -> &mut Self {
+        assert_eq!(names.len(), self.params.len());
+        for (name, p) in names.into_iter().zip(self.params.iter_mut()) {
+            p.param_name = Some(name.into());
+        }
+        self
+    }
+
     pub(crate) fn generate(
         self,
         documentation: &HashMap<NameContainer, String>,
@@ -102,6 +119,7 @@ impl ExportedFunction {
         );
         Ok(format!("{documentation}{metamethod}{name}: {signature}",))
     }
+
     ///Get all the generics that this function uses.
     pub fn get_generics(&self) -> HashSet<&Name> {
         self.params

--- a/src/exported_function.rs
+++ b/src/exported_function.rs
@@ -82,10 +82,11 @@ impl ExportedFunction {
     /// Will panic if the given argument does not have the same number of fields as [`params`].
     pub fn name_parameters(
         &mut self,
-        names: impl ExactSizeIterator<Item = impl Into<Name>>,
+        names: impl IntoIterator<IntoIter = impl ExactSizeIterator<Item = impl Into<Name>>>,
     ) -> &mut Self {
+        let names = names.into_iter();
         assert_eq!(names.len(), self.params.len());
-        for (name, p) in names.into_iter().zip(self.params.iter_mut()) {
+        for (name, p) in names.zip(self.params.iter_mut()) {
             p.param_name = Some(name.into());
         }
         self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,25 +17,21 @@ use std::{borrow::Cow, collections::HashSet};
 pub use exported_function::ExportedFunction;
 use serde::{Deserialize, Serialize};
 pub use teal_multivalue::{TealMultiValue, TealType};
-
-///Implements [ToTypename](crate::ToTypename).
-///
-///`TypeName::get_type_name` will return the name of the rust type.
-#[cfg(feature = "derive")]
-pub use tealr_derive::ToTypename;
-
-pub use type_generator::{EnumGenerator, Field, NameContainer, RecordGenerator, TypeGenerator};
-pub use type_representation::{type_parts_to_str, KindOfType, NamePart, TypeBody, TypeName};
-pub use type_walker::{ExtraPage, GlobalInstance, TypeWalker};
-
 #[cfg(feature = "compile")]
 pub use tealr_derive::compile_inline_teal;
-
 #[cfg(any(
     feature = "embed_compiler_from_local",
     feature = "embed_compiler_from_download"
 ))]
 pub use tealr_derive::embed_compiler;
+///Implements [ToTypename](crate::ToTypename).
+///
+///`TypeName::get_type_name` will return the name of the rust type.
+#[cfg(feature = "derive")]
+pub use tealr_derive::ToTypename;
+pub use type_generator::{EnumGenerator, Field, NameContainer, RecordGenerator, TypeGenerator};
+pub use type_representation::{type_parts_to_str, KindOfType, NamePart, TypeBody, TypeName};
+pub use type_walker::{ExtraPage, GlobalInstance, TypeWalker};
 
 /// Gets the current version of tealr.
 ///
@@ -244,7 +240,7 @@ pub fn new_type_to_old(a: Type, is_callback: bool) -> Cow<'static, [NamePart]> {
             parts.extend(new_type_to_old(*x, true).iter().cloned());
             parts.push(NamePart::symbol("}"));
             parts.into()
-        }
+        },
         Type::Map(MapRepresentation { key, value }) => {
             let mut parts = Vec::with_capacity(5);
             parts.push(NamePart::symbol("{"));
@@ -253,7 +249,7 @@ pub fn new_type_to_old(a: Type, is_callback: bool) -> Cow<'static, [NamePart]> {
             parts.extend(new_type_to_old(*value, true).iter().cloned());
             parts.push(NamePart::symbol("}"));
             parts.into()
-        }
+        },
         Type::Or(x) => {
             if x.is_empty() {
                 eprintln!("An NewType::Or found with empty contents. Skipping");
@@ -269,7 +265,7 @@ pub fn new_type_to_old(a: Type, is_callback: bool) -> Cow<'static, [NamePart]> {
             parts.pop();
             parts.push(NamePart::symbol(")"));
             parts.into()
-        }
+        },
         Type::Tuple(x) => {
             if x.is_empty() {
                 eprintln!("An NewType::Tuple found with empty contents. Skipping");
@@ -284,7 +280,7 @@ pub fn new_type_to_old(a: Type, is_callback: bool) -> Cow<'static, [NamePart]> {
             parts.pop();
             parts.push(NamePart::symbol(")"));
             parts.into()
-        }
+        },
         Type::Function(FunctionRepresentation { params, returns }) => {
             let mut parts = Vec::with_capacity(params.len() + returns.len());
             parts.push(NamePart::symbol("function"));
@@ -333,7 +329,7 @@ pub fn new_type_to_old(a: Type, is_callback: bool) -> Cow<'static, [NamePart]> {
             }
 
             Cow::Owned(parts)
-        }
+        },
     }
 }
 ///Gets the generics of any given type
@@ -353,12 +349,12 @@ pub fn get_generics(to_check: &Type) -> HashSet<&Name> {
                 set.insert(&x.name);
             }
             set
-        }
+        },
         Type::Or(x) | Type::Tuple(x) => x.iter().flat_map(get_generics).collect(),
         Type::Map(MapRepresentation { key, value }) => {
             let mut generics = get_generics(key);
             generics.extend(get_generics(value));
             generics
-        }
+        },
     }
 }

--- a/src/mlu.rs
+++ b/src/mlu.rs
@@ -11,6 +11,10 @@ pub mod user_data_proxy;
 pub(crate) mod user_data_wrapper;
 use std::borrow::Cow;
 
+pub use mlua;
+use mlua::{UserDataRef, UserDataRefMut};
+pub use teal_data_fields::TealDataFields;
+
 pub use self::{
     picker_macro::FromLuaExact,
     teal_data::TealData,
@@ -24,9 +28,6 @@ pub use crate::{
     mlua_create_named_parameters as create_named_parameters,
 };
 use crate::{ToTypename, Type};
-pub use mlua;
-use mlua::{UserDataRef, UserDataRefMut};
-pub use teal_data_fields::TealDataFields;
 
 pub(crate) fn get_meta_name(name: mlua::MetaMethod) -> Cow<'static, str> {
     use mlua::MetaMethod;
@@ -82,25 +83,25 @@ pub(crate) fn get_meta_name(name: mlua::MetaMethod) -> Cow<'static, str> {
 ///used by the `mlua_send` feature
 pub trait MaybeSend: Send {}
 #[cfg(feature = "mlua_send")]
-impl<T: Send> MaybeSend for T {}
+impl<T: Send> MaybeSend for T {
+}
 
 #[cfg(not(feature = "mlua_send"))]
 ///used by the `mlua_send` feature
 pub trait MaybeSend {}
 #[cfg(not(feature = "mlua_send"))]
-impl<T> MaybeSend for T {}
+impl<T> MaybeSend for T {
+}
 
 #[doc = include_str!("mlu/to_from_macro_doc.md")]
 #[cfg(feature = "derive")]
 pub use tealr_derive::MluaFromToLua as FromToLua;
-
 ///Implement both [mlua::UserData](mlua::UserData) and [TypeName](crate::ToTypename).
 ///
 ///Look at [tealr_derive::MluaUserData](tealr_derive::MluaUserData) and [tealr_derive::TypeName](tealr_derive::TypeName)
 ///for more information on how the implemented traits will behave.
 #[cfg(feature = "derive")]
 pub use tealr_derive::MluaTealDerive as TealDerive;
-
 ///Implements [UserData](mlua::UserData) and [TypeBody](crate::TypeBody)
 ///
 ///It wraps the [mlua::UserDataMethods](mlua::UserDataMethods) into [UserDataWrapper](crate::mlu::UserDataWrapper)
@@ -114,9 +115,11 @@ impl<T: ToTypename> ToTypename for UserDataRef<T> {
     fn to_typename() -> Type {
         T::to_typename()
     }
+
     fn to_function_param() -> Vec<crate::FunctionParam> {
         T::to_function_param()
     }
+
     fn to_old_type_parts() -> Cow<'static, [crate::NamePart]> {
         #[allow(deprecated)]
         T::to_old_type_parts()
@@ -127,9 +130,11 @@ impl<T: ToTypename> ToTypename for UserDataRefMut<T> {
     fn to_typename() -> Type {
         T::to_typename()
     }
+
     fn to_function_param() -> Vec<crate::FunctionParam> {
         T::to_function_param()
     }
+
     fn to_old_type_parts() -> Cow<'static, [crate::NamePart]> {
         #[allow(deprecated)]
         T::to_old_type_parts()

--- a/src/mlu/picker_macro.rs
+++ b/src/mlu/picker_macro.rs
@@ -1,10 +1,11 @@
-use mlua::{Error, Function, Lua, Table, Value};
-use std::ops::Deref;
 use std::{
     collections::{BTreeMap, HashMap},
     ffi::{CStr, CString},
     num::TryFromIntError,
+    ops::Deref,
 };
+
+use mlua::{Error, Function, Lua, Table, Value};
 
 /// similar to [mlua::FromLua](mlua::FromLua). However,
 /// however going through this trait you promise that the conversion to a rust value prefers failing over converting/casting

--- a/src/mlu/teal_data.rs
+++ b/src/mlu/teal_data.rs
@@ -1,6 +1,5 @@
-use crate::ToTypename;
-
 use super::{TealDataFields, TealDataMethods};
+use crate::ToTypename;
 
 ///This is the teal version of [UserData](mlua::UserData).
 pub trait TealData: Sized + ToTypename {
@@ -9,11 +8,13 @@ pub trait TealData: Sized + ToTypename {
     ///
     ///only difference is that it takes a [TealDataMethods](crate::mlu::TealDataMethods),
     ///which is the teal version of [UserDataMethods](mlua::UserDataMethods)
-    fn add_methods<T: TealDataMethods<Self>>(_methods: &mut T) {}
+    fn add_methods<T: TealDataMethods<Self>>(_methods: &mut T) {
+    }
     ///same as [UserData::add_fields](mlua::UserData::add_fields).
     ///Refer to its documentation on how to use it.
     ///
     ///only difference is that it takes a [TealDataFields](crate::mlu::TealDataFields),
     ///which is the teal version of [UserDataFields](mlua::UserDataFields)
-    fn add_fields<F: TealDataFields<Self>>(_fields: &mut F) {}
+    fn add_fields<F: TealDataFields<Self>>(_fields: &mut F) {
+    }
 }

--- a/src/mlu/teal_data_fields.rs
+++ b/src/mlu/teal_data_fields.rs
@@ -1,8 +1,7 @@
 use mlua::{AnyUserData, FromLua, IntoLua, Lua, MetaMethod};
 
-use crate::ToTypename;
-
 use super::{MaybeSend, TealData};
+use crate::ToTypename;
 
 ///The teal version of [UserDataFields](mlua::UserDataFields)
 ///

--- a/src/mlu/typed_function.rs
+++ b/src/mlu/typed_function.rs
@@ -61,6 +61,7 @@ where
     pub fn call(&self, params: Params) -> mlua::Result<Response> {
         self.inner_function.call(params)
     }
+
     ///Calls the function with the given parameters. Panics if something has gone wrong.
     pub fn force_call(&self, params: Params) -> Response {
         self.inner_function.call(params).unwrap()
@@ -106,6 +107,7 @@ where
             _r: PhantomData,
         })
     }
+
     ///make a typed function directly from a Rust one.
     pub fn from_rust_mut<
         Func: 'static + crate::mlu::MaybeSend + FnMut(&Lua, Params) -> mlua::Result<Response>,

--- a/src/mlu/user_data_proxy.rs
+++ b/src/mlu/user_data_proxy.rs
@@ -6,7 +6,8 @@ use crate::{EnumGenerator, RecordGenerator, ToTypename, Type, TypeBody, TypeName
 
 /// A userdata which can be used as a static proxy
 pub trait StaticUserdata: UserData + 'static {}
-impl<T: UserData + 'static> StaticUserdata for T {}
+impl<T: UserData + 'static> StaticUserdata for T {
+}
 
 /// A newtype storing proxy userdata created via [`mlua::Lua::create_proxy`].
 ///
@@ -72,13 +73,13 @@ impl<T: StaticUserdata + TypeBody + ToTypename> TypeBody for UserDataProxy<T> {
                     meta_method_mut: Default::default(),
                     ..record_generator.as_ref().clone()
                 }))
-            }
+            },
             crate::TypeGenerator::Enum(enum_generator) => {
                 crate::TypeGenerator::Enum(EnumGenerator {
                     name: Self::get_type_parts(),
                     ..enum_generator
                 })
-            }
+            },
         }
     }
 }

--- a/src/type_representation.rs
+++ b/src/type_representation.rs
@@ -63,6 +63,7 @@ impl KindOfType {
     pub fn is_generic(&self) -> bool {
         self == &Self::Generic
     }
+
     ///```
     ///# use tealr::KindOfType;
     ///assert!(KindOfType::Builtin.is_builtin());
@@ -70,6 +71,7 @@ impl KindOfType {
     pub fn is_builtin(&self) -> bool {
         self == &Self::Builtin
     }
+
     ///```
     ///# use tealr::KindOfType;
     ///assert!(KindOfType::External.is_external());
@@ -168,6 +170,7 @@ impl NamePart {
             NamePart::Type(x) => &x.name,
         }
     }
+
     ///checks if `&self` is of the `Symbol(_)` variant
     pub fn is_symbol(&self) -> bool {
         matches!(&self, NamePart::Symbol(_))
@@ -244,7 +247,8 @@ pub trait TypeName {
     }
     ///Creates/updates a list of every child type this type has
     ///This is used to properly label methods/functions as being generic.
-    fn collect_children(_: &mut Vec<TealType>) {}
+    fn collect_children(_: &mut Vec<TealType>) {
+    }
 }
 
 use std::{

--- a/src/type_walker.rs
+++ b/src/type_walker.rs
@@ -86,11 +86,13 @@ impl TypeWalker {
     pub fn new() -> Self {
         Default::default()
     }
+
     ///Adds a new page that should be included in the documentation
     pub fn add_page(mut self, name: String, content: String) -> Self {
         self.extra_page.push(ExtraPage { name, content });
         self
     }
+
     ///reads a file and adds it as an extra page
     pub fn add_page_from(
         &mut self,
@@ -101,10 +103,12 @@ impl TypeWalker {
         self.extra_page.push(ExtraPage { name, content });
         Ok(self)
     }
+
     ///gives an iterator back over every type
     pub fn iter(&self) -> std::slice::Iter<'_, TypeGenerator> {
         self.given_types.iter()
     }
+
     ///Process a type such that the body will be added directly into the module instead of becoming a child record.
     ///
     ///When embedding teal/lua there is probably not really a reason to do so.
@@ -114,18 +118,20 @@ impl TypeWalker {
         match &mut x {
             TypeGenerator::Record(x) => {
                 x.should_be_inlined = true;
-            }
+            },
             TypeGenerator::Enum(_) => (),
         }
         self.given_types.push(x);
         self
     }
+
     ///prepares a type to have a `.d.tl` file generated, and adds it to the list of types to generate.
     pub fn process_type<A: ToTypename + TypeBody>(mut self) -> Self {
         let x = <A as TypeBody>::get_type_body();
         self.given_types.push(x);
         self
     }
+
     ///generates the `.d.tl` file. It outputs the string, its up to you to store it.
     #[deprecated(
         since = "0.9.0",
@@ -187,6 +193,7 @@ impl TypeWalker {
             record = v
         ))
     }
+
     ///Same as calling [Typewalker::generate(outer_name,true)](crate::TypeWalker::generate).
     #[deprecated(
         since = "0.9.0",
@@ -196,6 +203,7 @@ impl TypeWalker {
         #[allow(deprecated)]
         self.generate(outer_name, true)
     }
+
     ///Same as calling [Typewalker::generate(outer_name,false)](crate::TypeWalker::generate).
     #[deprecated(
         since = "0.9.0",
@@ -205,12 +213,14 @@ impl TypeWalker {
         #[allow(deprecated)]
         self.generate(outer_name, false)
     }
+
     /// Generates the json needed by [tealr_doc_gen](https://crates.io/crates/tealr_doc_gen) to generate the documentation.
     ///
     /// It is up to you to store it properly
     pub fn to_json(&self) -> serde_json::Result<String> {
         serde_json::to_string(self)
     }
+
     /// Generates the json needed by [tealr_doc_gen](https://crates.io/crates/tealr_doc_gen) to generate the documentation in a pretty-printed way.
     ///
     /// It is up to you to store it properly.
@@ -218,10 +228,12 @@ impl TypeWalker {
     pub fn to_json_pretty(&self) -> serde_json::Result<String> {
         serde_json::to_string_pretty(self)
     }
+
     /// Checks if the version of tealr to create this [TypeWalker] is the same version as the current [tealr](crate) version
     pub fn check_correct_version(&self) -> bool {
         self.tealr_version_used == crate::get_tealr_version()
     }
+
     /// Gets the version of [tealr](crate) that was used to create this [TypeWalker]
     pub fn get_tealr_version_used(&self) -> &str {
         &self.tealr_version_used

--- a/tealr_derive/src/compile_inline_teal.rs
+++ b/tealr_derive/src/compile_inline_teal.rs
@@ -20,7 +20,7 @@ impl CompileConfig {
             Some(TokenTree::Literal(x)) => {
                 let stringified = x.to_string().trim().to_string();
                 stringified[1..(stringified.len() - 1)].to_string()
-            }
+            },
             Some(_) => return Err(venial::Error::new("Expected string literal")),
             None => return Err(venial::Error::new("Missing code to run")),
         };
@@ -32,7 +32,7 @@ impl CompileConfig {
                         x.as_char()
                     )));
                 }
-            }
+            },
             Some(x) => return Err(venial::Error::new(format!("Expected `,` got `{}`.", x))),
             None => (),
         }

--- a/tealr_derive/src/embed_compiler.rs
+++ b/tealr_derive/src/embed_compiler.rs
@@ -19,13 +19,11 @@ use syn::{parse::Parse, Ident, LitStr};
 
 #[cfg(feature = "embed_compiler_from_download")]
 use self::download_compiler::{download_teal_from_github, download_teal_from_luarocks};
-
 #[cfg(all(
     not(feature = "embed_compiler_from_download"),
     feature = "embed_compiler_from_local"
 ))]
 use self::download_compiler_mock::{download_teal_from_github, download_teal_from_luarocks};
-
 use self::load_from_disk::get_local_teal;
 
 #[derive(Debug)]
@@ -86,24 +84,24 @@ fn get_version(version: String) -> String {
                     return true;
                 }
                 false
-            }
+            },
             Checker::Number => {
                 if chara == '.' {
                     last = Checker::Dot;
                     return true;
                 }
                 chara.is_ascii_digit()
-            }
+            },
             Checker::Dot => {
                 if chara.is_ascii_digit() {
                     last = Checker::Number;
                     return true;
                 }
                 false
-            }
+            },
             Checker::Start => {
                 unreachable!()
-            }
+            },
         }
     });
     if !is_valid_version {

--- a/tealr_derive/src/embed_compiler/download_compiler.rs
+++ b/tealr_derive/src/embed_compiler/download_compiler.rs
@@ -16,7 +16,7 @@ pub(crate) fn download_teal(url: String, main_folder: String) -> String {
             eprintln!("Did not get a success status. Got: {}", state);
             eprintln!("Message: {:?}", res);
             res
-        }
+        },
         Err(x) => panic!("Failed downloading teal compiler. Error:{}", x),
     };
     let mut reader = res.into_reader();

--- a/tealr_derive/src/embed_compiler/load_from_disk.rs
+++ b/tealr_derive/src/embed_compiler/load_from_disk.rs
@@ -47,10 +47,10 @@ pub(crate) fn get_local_teal(path: String) -> String {
                 match e.kind() {
                     std::io::ErrorKind::NotFound => {
                         "Could not compile teal. Command `tl` not found."
-                    }
+                    },
                     std::io::ErrorKind::PermissionDenied => {
                         "Permission denied when running the teal compiler."
-                    }
+                    },
                     _ => "Error while running teal. Is it available as `tl` in the path?",
                 },
                 e,
@@ -70,7 +70,7 @@ pub(crate) fn get_local_teal(path: String) -> String {
                     .unwrap_or_default(),
                 e.kind()
             )
-        }
+        },
     };
 
     if !compiler

--- a/tealr_derive/src/from_to_lua.rs
+++ b/tealr_derive/src/from_to_lua.rs
@@ -45,8 +45,8 @@ fn find_tag_with_value(to_find: &str, tags: &[venial::Attribute]) -> Option<Toke
                 } else {
                     None
                 }
-            }
-            venial::AttributeValue::Equals(_, _) => None,
+            },
+            venial::AttributeValue::Equals(..) => None,
         })
 }
 
@@ -57,7 +57,7 @@ fn find_doc_tags(tags: &[venial::Attribute]) -> impl Iterator<Item = String> + '
             name == "lua_doc" || name == "doc" || name == "tealr_doc"
         })
         .filter_map(|v| match &v.value {
-            venial::AttributeValue::Group(_, _) => None,
+            venial::AttributeValue::Group(..) => None,
             venial::AttributeValue::Equals(_, y) => Some(
                 y.iter()
                     .flat_map(|v| {

--- a/tealr_derive/src/lib.rs
+++ b/tealr_derive/src/lib.rs
@@ -48,8 +48,9 @@ pub fn type_representation_derive(input: TokenStream) -> TokenStream {
 #[cfg(feature = "derive")]
 #[proc_macro_derive(MluaTealDerive, attributes(tealr))]
 pub fn mlua_teal_derive(input: TokenStream) -> TokenStream {
-    use crate::user_data::impl_type_representation_derive;
     use user_data::impl_mlua_user_data_derive;
+
+    use crate::user_data::impl_type_representation_derive;
 
     let ast = parse_item(input.into()).unwrap();
 
@@ -73,7 +74,6 @@ mod compile_inline_teal;
 ///# use tealr_derive::compile_inline_teal;
 ///assert_eq!(compile_inline_teal!("local a : number = 1"),"local a = 1\n")
 ///```
-
 #[cfg(feature = "compile")]
 #[proc_macro]
 pub fn compile_inline_teal(input: TokenStream) -> TokenStream {

--- a/tealr_derive/src/user_data.rs
+++ b/tealr_derive/src/user_data.rs
@@ -51,7 +51,7 @@ pub(crate) fn impl_mlua_user_data_derive(ast: &Item) -> TokenStream {
         _ => {
             return Error::new("As of right now, only structs and enums are supported.")
                 .to_compile_error()
-        }
+        },
     };
     let type_body = generate_type_body(
         name,

--- a/tests/readme_pieces.rs
+++ b/tests/readme_pieces.rs
@@ -71,6 +71,7 @@ impl TealData for Example {
             |_, _, fun: TypedFunction<String, X>| fun.call("A nice string!".to_string()),
         );
     }
+
     fn add_fields<F: tealr::mlu::TealDataFields<Self>>(fields: &mut F) {
         fields.add_field_method_get("example", |_, this| Ok(this.example));
         fields.add_field_method_set("example", |_, this, value| {


### PR DESCRIPTION
I'm using this library to generate API documentation for my game, and I found that the way I define my API does not seem to extract the names of function arguments.

```rs
#[derive(Clone, tealr::mlu::UserData, ToTypename)]
struct ApiUi;

impl ApiUi {
    fn get_by_id(_: &Lua, _: String) -> Result<Option<ElementRef>, tealr::mlu::mlua::Error> {
        Ok(None)
    }
}

impl tealr::mlu::TealData for ApiUi {
    // implement your methods/functions
    fn add_methods<T: tealr::mlu::TealDataMethods<Self>>(methods: &mut T) {
        methods.document_type("Api to interface with the UI.");
        methods.document("find element by the given ID");
        methods
            .add_function("get_by_id", Self::get_by_id) // does not auto detect the parameter names
            .name_parameters(["id"]);
```

For my use case it made a lot of sense to have the functions return `&mut ExportedFunction` so I can tweak the generated documentation a bit. I figured it might be useful to upstream this in case other people also want this.

Feel free to suggest a different solution to set function parameter names if you know a better structure, and I'll implement it.